### PR TITLE
Removed a non-functional link for FAQs

### DIFF
--- a/06-Security-Telemetry/Readme.md
+++ b/06-Security-Telemetry/Readme.md
@@ -14,7 +14,6 @@
   - [App Insights Visualization](#app-insights-visualization)
 - [Usage Telemetry](#usage-telemetry)
   - [Enable/Disable Usage Telemetry](#enabledisable-usage-telemetry)
-- [FAQs](#faqs)
 
 ## Overview
 


### PR DESCRIPTION
There was an FAQs link present in the page despite there being no FAQs for security telemetry. Hence, I removed that link.