### PR TITLE
Extending new SVT + Az migration steps for ext customer

### DIFF
--- a/07-Customizing-AzSK-for-your-Org/OrgPolicyUpdate.md
+++ b/07-Customizing-AzSK-for-your-Org/OrgPolicyUpdate.md
@@ -20,6 +20,17 @@ Update-AzSKOrganizationPolicy -SubscriptionId <SubscriptionId> `
    -PolicyFolderPath "D:\ContosoPolicies" -OverrideBaseConfig OrgAzSKVersion
 ```
 
+# AzSK v.3.11.0
+
+*	The big change in this release is the migration of the DevOps Kit from AzureRM to the new Az-* PowerShell libraries
+> **Note:** If you are upgrading from version 3.10.0 or below, you need to follow the below steps
+> 1. Org-policy owner should download the latest AzSK module using the command: *"Install-Module AzSK -Scope CurrentUser -AllowClobber -Force
+"*.
+> 2. Import the latest AzSK module in a fresh PowerShell session and update your org-policy using the command: *"Update-AzSKOrganizationPolicy -SubscriptionId `<SubId>` -OrgName `<OrgName>` -DepartmentName `<DepartmentName>` -PolicyFolderPath `<PolicyFolderPath>` -OverrideBaseConfig All"*
+> 3. Run the iwr and update the CA by running the *"Update-AzSKContinuousAssurance"* command with the *"-FixModules"* switch.
+
+* Update all the AzureRM and Azure commands in your SVT extensions to its equivalent in the Az-* module.
+
 # AzSK v.3.9.0
 
 *	The ARM Checker task in AzSK CICD Extension now respects org policy ' this will let org policy owners customize behavior of the task. (Note that this was possible for the SVT task earlier'only the ARM Checker task was missing the capability.)

--- a/08-Advanced-Features/Extending AzSK Module/AppInsights.ext.json
+++ b/08-Advanced-Features/Extending AzSK Module/AppInsights.ext.json
@@ -1,0 +1,24 @@
+{
+    "FeatureName": "AppInsights",
+    "Reference": "aka.ms/azsktcp/appinsights", 
+    "IsMaintenanceMode": false,
+    "Controls": [
+        {
+            "ControlID": "Azure_AppInsights_No_Limited_Basic_Plan", 
+            "Description": "Do not use ‘Limited Basic' tier plan for enterprise apps.", 
+            "Id": "AppInsights1001", 
+            "ControlSeverity": "Medium", 
+            "Automated": "Yes",  
+            "MethodName": "CheckAIPricingPlan", 
+            "Recommendation": "Use an enterprise grade pricing plan other than ‘Limited Basic’.",
+            "Tags": [
+                "SDL",
+                "Best Practice",
+                "Automated",
+                "AppInsights"
+            ],
+            "Enabled": true,
+            "Rationale": "Logical intention for the extended control"
+        }
+    ]
+}

--- a/08-Advanced-Features/Extending AzSK Module/AppInsights.ext.ps1
+++ b/08-Advanced-Features/Extending AzSK Module/AppInsights.ext.ps1
@@ -1,0 +1,28 @@
+Set-StrictMode -Version Latest
+    
+# Class name must have Ext suffix. Class must be inherited from Feature class
+class AppInsightsExt: AppInsights
+{       
+    AppInsightsExt([string] $subscriptionId, [SVTResource] $svtResource):
+        Base($subscriptionId, $svtResource)
+    { 
+        $this.GetResourceObject();
+    }
+
+    hidden [ControlResult] CheckAIPricingPlan([ControlResult] $controlResult)
+    {
+        # Your function logic goes here.
+        Write-Host("Checking AI pricing plan...")
+        $ai = $this.ResourceObject
+        if ($ai.PricingPlan -eq 'Limited Basic')
+        {
+            $controlResult.VerificationResult = [VerificationResult]::Failed
+            $controlResult.AddMessage("AI: Use an enterprise grade pricing plan other than ‘Limited Basic’");
+        }
+        else {
+            $controlResult.VerificationResult = [VerificationResult]::Passed
+            $controlResult.AddMessage("AI: Non-basic plan is used per expectation!");
+        }
+        return $controlResult;
+    }
+} 

--- a/08-Advanced-Features/Extending AzSK Module/AppInsights.json
+++ b/08-Advanced-Features/Extending AzSK Module/AppInsights.json
@@ -1,0 +1,6 @@
+{
+    "FeatureName": "AppInsights",
+    "Reference": "aka.ms/azsktcp/appinsights",
+    "IsMaintenanceMode": false,
+    "Controls": []
+}

--- a/08-Advanced-Features/Extending AzSK Module/AppInsights.ps1
+++ b/08-Advanced-Features/Extending AzSK Module/AppInsights.ps1
@@ -1,0 +1,28 @@
+Set-StrictMode -Version Latest
+class AppInsights: SVTBase
+{
+    hidden [PSObject] $ResourceObject;
+
+    AppInsights([string] $subscriptionId, [SVTResource] $svtResource):
+        Base($subscriptionId, $svtResource)
+    {
+        $this.GetResourceObject();
+    }
+
+    hidden [PSObject] GetResourceObject()
+    {
+        if (-not $this.ResourceObject)
+        {
+            # Get resource details from AzureRm
+            $this.ResourceObject = Get-AzureRmApplicationInsights -Name $this.ResourceContext.ResourceName -ResourceGroupName $this.ResourceContext.ResourceGroupName -Full 
+
+            if(-not $this.ResourceObject)
+            {
+                throw ([SuppressedException]::new(("Resource '$($this.ResourceContext.ResourceName)' not found under Resource Group '$($this.ResourceContext.ResourceGroupName)'"), [SuppressedExceptionType]::InvalidOperation))
+            }
+            
+        }
+
+        return $this.ResourceObject;
+    }
+}

--- a/08-Advanced-Features/Extending AzSK Module/Readme.md
+++ b/08-Advanced-Features/Extending AzSK Module/Readme.md
@@ -8,6 +8,7 @@
 - [Steps to override the logic of existing SVT](Readme.md#steps-to-override-the-logic-of-existing-svt)  
 - [Steps to add extended control in baseline control list](Readme.md#steps-to-add-extended-control-in-baseline-control-list)  
 - [Steps to debug the extended control while developement](Readme.md#steps-to-debug-the-extended-control-while-development)  
+- [Steps to add a new SVT to the AzSK module](Readme.md#steps-to-add-a-new-SVT-to-the-AzSK-module)
 - [FAQ](Readme.md#faqs)  
 - [References](Readme.md#references) 
 
@@ -286,6 +287,188 @@ class SubscriptionCore: SVTBase
 
 Extended Feature.ext.ps1 files are downloaded at C:\Users\<UserAccount>\AppData\Local\Microsoft\AzSK\Extensions folder in the execution machine. While debugging, breakpoints need be inserted in those files. 
 
+### Steps to add a new SVT to the AzSK module:
+
+The following instructions will help you develop SVT for a new Azure service from scratch. That is, using these steps you can add an SVT for an Azure service that is not currently supported in DevOps Kit.
+
+For illustration purpose, we will be developing SVT for Application Insights (as Application Insights is a resource type not currently supported in the DevOps kit.)
+
+>**Note:** Currently, adding a completely new SVT to AzSK requires collaboration with the DevOps Kit team. This is because we need to make some changes in the core module to support the new SVT. Please email azsksup@microsoft.com to initiate a discussion. Typically, we will be able to turn such requests around within our monthly sprint. 
+
+> However, while that process is under way, you can still make progress on this task and, in fact, have a completely functioning new SVT created and tested within your org. Only thing is that you may need to do some renaming/minor file updates after the base support is included by the DevOps Kit team in the AzSK code (after which you can deploy for all users in your org for SDL/CICD/usage).
+
+>All steps will eventually be done by the DevOps Kit team and included in the core AzSK code below marked ###.
+
+The steps below follow roundabout the same model as in section [Extending AzSK Module](Readme.md#block-diagram-to-represent-the-extension-model). All controls you implement for the new SVT will be treated as ‘extended’ controls of a blank core SVT.
+
+1. [###] Create files AppInsights.json and AppInsights.ps1 to represent base classes/control placeholders in the core module.
+
+    Basically these files will serve the purpose of the (within-module) base class for AppInsights SVT and the controls you will write will go into the SVT extension.
+
+    a.	Save AppInsights.json (content below) to <pathToAzSK>\AzSK\<version>\Framework\Configurations\SVT\Services.
+    
+    AppInsights.json
+
+    ```PowerShell
+    {
+    "FeatureName": "AppInsights",
+    "Reference": "aka.ms/azsktcp/appinsights",
+    "IsMaintenanceMode": false,
+    "Controls": []
+    }
+    ```
+
+    b.	Save AppInsights.ps1 (content below) to <pathToAzSK>\AzSK\<version>\Framework\Core\SVT\Services.
+
+    AppInsights.ps1
+
+    ``` PowerShell
+    Set-StrictMode -Version Latest
+    class AppInsights: SVTBase
+    {
+        hidden [PSObject] $ResourceObject;
+    
+        AppInsights([string] $subscriptionId, [SVTResource] $svtResource):
+            Base($subscriptionId, $svtResource)
+        {
+            $this.GetResourceObject();
+        }
+    
+        hidden [PSObject] GetResourceObject()
+        {
+            if (-not $this.ResourceObject)
+            {
+                # Get resource details from AzureRm
+                $this.ResourceObject = Get-AzureRmApplicationInsights -Name $this.ResourceContext.ResourceName -ResourceGroupName $this.ResourceContext.ResourceGroupName -Full 
+    
+                if(-not $this.ResourceObject)
+                {
+                    throw ([SuppressedException]::new(("Resource '$($this.ResourceContext.ResourceName)' not found under Resource Group '$($this.ResourceContext.ResourceGroupName)'"), [SuppressedExceptionType]::InvalidOperation))
+                }
+                
+            }
+    
+            return $this.ResourceObject;
+        }
+    }
+    ```
+
+    Note that the content/structure of these files is similar to the other SVT base class files (e.g., Batch.json/Batch.ps1). Only that these are hollow classes (i.e., they do not have any controls implemented.)
+
+2. Create AppInsights.ext.json and AppInsights.ext.ps1 (using the content below) wherever you store AzSK extension code in your source tree.
+
+    Also copy these files to the (local) org policy folder (e.g., %userprofile%\Desktop\ContosoPolicies).
+
+    Note that below we have implemented a single dummy control for App Insights called ‘Azure_AppInsights_No_Limited_Basic_Plan’ (which merely checks and fails if the pricing plan is ‘Limited Basic’). 
+
+    AppInsights.ext.json
+
+    ```PowerShell
+    {
+        "FeatureName": "AppInsights",
+        "Reference": "aka.ms/azsktcp/appinsights", 
+        "IsMaintenanceMode": false,
+        "Controls": [
+            {
+                "ControlID": "Azure_AppInsights_No_Limited_Basic_Plan", 
+                "Description": "Do not use ‘Limited Basic' tier plan for enterprise apps.", 
+                "Id": "AppInsights1001", 
+                "ControlSeverity": "Medium", 
+                "Automated": "Yes",  
+                "MethodName": "CheckAIPricingPlan", 
+                "Recommendation": "Use an enterprise grade pricing plan other than ‘Limited Basic’.",
+                "Tags": [
+                    "SDL",
+                    "Best Practice",
+                    "Automated",
+                    "AppInsights"
+                ],
+                "Enabled": true,
+                "Rationale": "Logical intention for the extended control"
+            }
+        ]
+    }
+    ```
+
+    AppInsights.ext.ps1
+
+    ``` PowerShell
+    Set-StrictMode -Version Latest
+    
+    # Class name must have Ext suffix. Class must be inherited from Feature class
+    class AppInsightsExt: AppInsights
+    {       
+        AppInsightsExt([string] $subscriptionId, [SVTResource] $svtResource):
+            Base($subscriptionId, $svtResource)
+        { 
+            $this.GetResourceObject();
+        }
+    
+        hidden [ControlResult] CheckAIPricingPlan([ControlResult] $controlResult)
+        {
+            # Your function logic goes here.
+            Write-Host("Checking AI pricing plan...")
+            $ai = $this.ResourceObject
+            if ($ai.PricingPlan -eq 'Limited Basic')
+            {
+                $controlResult.VerificationResult = [VerificationResult]::Failed
+                $controlResult.AddMessage("AI: Use an enterprise grade pricing plan other than ‘Limited Basic’");
+            }
+            else {
+                $controlResult.VerificationResult = [VerificationResult]::Passed
+                $controlResult.AddMessage("AI: Non-basic plan is used per expectation!");
+            }
+            return $controlResult;
+        }
+    } 
+    ```
+
+3.	Now push the extension files to the org policy server using the command below:
+
+    ``` PowerShell
+    Update-AzSKOrganizationPolicy -SubscriptionId <SubscriptionId> `
+    -OrgName "Contoso" `
+    -DepartmentName "IT" `
+    -PolicyFolderPath "%userprofile%\Desktop\ContosoPolicies"
+    ```
+
+4.	[###] Edit AllResourceTypes.json (<pathToAzSK>\AzSK\<version>\Framework\Configurations\SVT\) in the local module by adding an entry for the Application Insights resource type at the end (note the comma).
+
+    Basically, this is where AzSK looks in the core module code to determine if a resource type is supported or not.
+
+    ``` PowerShell
+                                     ,
+      "Microsoft.Insights/Components"
+    ]
+    ```
+    >**Note:** To determine the exact name for a resource type you are trying to implement an SVT for, you can use the following commands (shown here for Application Insights):
+
+    ```PowerShell
+    # List all RPs/registration state:
+    Get-AzureRmResourceProvider -ListAvailable | Select-Object ProviderNamespace, RegistrationState
+    
+    # microsoft.insights
+    (Get-AzureRmResourceProvider -ProviderNamespace microsoft.insights).ResourceTypes.ResourceTypeName
+    ```
+5.	[###] Edit SVTMapping.ps1 (<pathToAzSK>\AzSK\<version>\Framework\Helpers) to add a resource type mapping entry for Application Insights.
+
+    This mapping is how AzSK determines which PowerShell class implements the controls for the resource type.
+
+    ```PowerShell
+        [ResourceTypeMapping]@{
+            ResourceType = "Microsoft.Insights/Components";
+            ClassName = "AppInsights";
+            JsonFileName = "AppInsights.json";
+            ResourceTypeName = "AppInsights";
+        },
+    ```
+6.	(In a fresh PS session) Run the following scan command to evaluate the control:
+
+    ```PowerShell
+      Get-AzSKAzureServicesSecurityStatus -SubscriptionId <SubscriptionId> -ResourceTypeName AppInsights
+      #or
+      Get-AzSKAzureServicesSecurityStatus -SubscriptionId <SubscriptionId> -ResourceGroupNames <RGName> -ResourceNames <AppInsightsRsrcName>
+    ```
 ### FAQs:
 
 #### I have added ext control in Storage/AppService/VirtualMachine feature as per documentation. My control is still not getting executed. The control is not even coming as Manual in the csv.


### PR DESCRIPTION
Updated steps to add altogether new SVT. Added the corresponding files as well.

Updated the org policy update for 3.11.0 with steps for migrating the org policy to the Az module. Also, added note for updating the already extended SVTs with the Az-* commands.