### PR TITLE
Extra line in summary

### DIFF
--- a/03-Security-In-CICD/Readme.md
+++ b/03-Security-In-CICD/Readme.md
@@ -7,7 +7,8 @@
 ![Security_In_CICD](../Images/Security_In_CICD.png)
  
 ## Contents
-- [Overview](Readme.md#overview) 
+- [Overview](Readme.md#overview)
+
 ## [Security Verification Tests (SVTs) in VSTS pipeline](Readme.md#security-verification-tests-svts-in-VSTS-pipeline) 
 - [Enable AzSK extension for your VSTS](Readme.md#enable-azsk-extension-for-your-vsts)
 - [Walkthrough](Readme.md#walkthrough)


### PR DESCRIPTION
Without this extra line, azsk website is rendering the summary incorrectly.

https://azsk.azurewebsites.net/03-Security-In-CICD/Readme.html

![image](https://user-images.githubusercontent.com/1991286/58577563-1e911d80-821d-11e9-8153-5973b36785cb.png)
